### PR TITLE
Refactor Alpine.js Stores to Consolidate as a Single Store

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -123,23 +123,33 @@ namespace SRF;
 
 <script>
 	document.addEventListener('alpine:init', () => {
-		Alpine.store('mobileDropdown', {
-			tab: 0
+		// Centralized store for all accordion UIs
+		Alpine.store('accordionStore', {
+			tabs: {},
+			getTab(key) {
+				return this.tabs[key] || 0;
+			},
+			setTab(key, value) {
+				this.tabs[key] = this.tabs[key] === value ? 0 : value;
+			}
 		});
 
-		Alpine.data('mobileDropdown', (xid) => ({
+		// Generic Alpine data for accordion UIs
+		Alpine.data('accordionUI', (storeKey, xid) => ({
 			xid: null,
+			storeKey: null,
 			init() {
 				this.xid = xid;
+				this.storeKey = storeKey;
 			},
 			handleClick() {
-				this.$store.mobileDropdown.tab = this.$store.mobileDropdown.tab === this.xid ? 0 : this.xid;
+				this.$store.accordionStore.setTab(this.storeKey, this.xid);
 			},
 			handleRotate() {
-				return this.$store.mobileDropdown.tab === this.xid ? 'rotate-180' : '';
+				return this.$store.accordionStore.getTab(this.storeKey) === this.xid ? 'rotate-180' : '';
 			},
 			handleToggle() {
-				return this.$store.mobileDropdown.tab === this.xid
+				return this.$store.accordionStore.getTab(this.storeKey) === this.xid
 					? `max-height: ${this.$refs.tab.scrollHeight}px`
 					: '';
 			}

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -344,7 +344,7 @@ if ( ! function_exists( 'srf_mobile_nav_item' ) ) :
 	 */
 	function srf_mobile_nav_item( $name, $data_item, $subnav_items ) {
 		$output = sprintf(
-			'<li class="bg-white" x-data="mobileDropdown(%1$s)">
+			'<li class="bg-white" x-data="accordionUI(\'mobileDropdown\', %1$s)">
 				<h3
 				@click="handleClick()"
 				class="flex flex-row justify-between items-center font-semibold text-gray-600 p-4 cursor-pointer"

--- a/page-donate.php
+++ b/page-donate.php
@@ -53,7 +53,7 @@ get_header();
 			<p class="text-center lg:w-4/6 mx-auto">In addition to credit card above, you can donate via the
 				following:</p>
 			<ul class="flex flex-col">
-				<li class="bg-white border border-b-0 rounded-t-md" x-data="accordion(1)">
+				<li class="bg-white border border-b-0 rounded-t-md" x-data="accordionUI('accordion', 1)">
 					<h3
 						@click="handleClick()"
 						class="flex flex-row justify-between items-center font-semibold text-gray-600 p-4 cursor-pointer"
@@ -127,7 +127,7 @@ get_header();
 						</div>
 					</div>
 				</li>
-				<li class="bg-white border border-b-0" x-data="accordion(2)">
+				<li class="bg-white border border-b-0" x-data="accordionUI('accordion', 2)">
 					<div
 						@click="handleClick()"
 						class="flex flex-row justify-between items-center font-semibold text-gray-600 p-4 cursor-pointer"
@@ -208,7 +208,7 @@ get_header();
 						</div>
 					</div>
 				</li>
-				<li class="bg-white border border-b-0" x-data="accordion(3)">
+				<li class="bg-white border border-b-0" x-data="accordionUI('accordion', 3)">
 					<div
 						@click="handleClick()"
 						class="flex flex-row justify-between items-center font-semibold text-gray-600 p-4 cursor-pointer"
@@ -268,30 +268,5 @@ get_header();
 		</div>
 	</div>
 
-	<script>
-		document.addEventListener('alpine:init', () => {
-			Alpine.store('accordion', {
-				tab: 0
-			});
-
-			Alpine.data('accordion', (xid) => ({
-				xid: null,
-				init() {
-					this.xid = xid;
-				},
-				handleClick() {
-					this.$store.accordion.tab = this.$store.accordion.tab === this.xid ? 0 : this.xid;
-				},
-				handleRotate() {
-					return this.$store.accordion.tab === this.xid ? 'rotate-180' : '';
-				},
-				handleToggle() {
-					return this.$store.accordion.tab === this.xid
-						? `max-height: ${this.$refs.tab.scrollHeight}px`
-						: '';
-				}
-			}));
-		});
-	</script>
-	<?php
+<?php
 get_footer();


### PR DESCRIPTION
This pull request refactors the accordion UI logic in the codebase to centralize state management and make the implementation more reusable. The changes replace multiple individual Alpine.js stores and data components with a single shared `accordionStore` and a generic `accordionUI` data component.

### Refactoring for centralized state management:

* Replaced the `mobileDropdown` store with a new centralized `accordionStore` in `footer.php`. The new store manages tabs for all accordion UIs by key, improving reusability and reducing duplication.
* Introduced a generic `accordionUI` Alpine.js data component in `footer.php` to replace individual accordion implementations. This component uses `accordionStore` for state management and provides common methods like `handleClick`, `handleRotate`, and `handleToggle`.

### Updates to existing components:

* Updated `srf_mobile_nav_item` in `inc/template-tags.php` to use the new `accordionUI` component instead of the old `mobileDropdown` implementation.
* Replaced individual accordion instances in `page-donate.php` with the new `accordionUI` component, simplifying the logic and aligning it with the centralized state management approach. [[1]](diffhunk://#diff-a4d4cdee178a9257f873ae2b732ee30d6507626bf190d087549148a0b0ab91a0L56-R56) [[2]](diffhunk://#diff-a4d4cdee178a9257f873ae2b732ee30d6507626bf190d087549148a0b0ab91a0L130-R130) [[3]](diffhunk://#diff-a4d4cdee178a9257f873ae2b732ee30d6507626bf190d087549148a0b0ab91a0L211-R211)

### Cleanup of redundant code:

* Removed the old `accordion` store and related Alpine.js data component from `page-donate.php`, as they are now replaced by the centralized `accordionStore` and `accordionUI`.