### PR TITLE
Consolidate Podcast Templates

### DIFF
--- a/acf-json/group_podcast_taxonomy.json
+++ b/acf-json/group_podcast_taxonomy.json
@@ -1,0 +1,96 @@
+{
+	"key": "group_podcast_taxonomy",
+	"title": "Podcast Category Settings",
+	"fields": [
+		{
+			"key": "field_podcast_image",
+			"label": "Podcast Image",
+			"name": "podcast_image",
+			"type": "image",
+			"instructions": "Upload the podcast cover image",
+			"required": 1,
+			"return_format": "url",
+			"preview_size": "medium",
+			"library": "all"
+		},
+		{
+			"key": "field_podcast_description",
+			"label": "Podcast Description",
+			"name": "podcast_description",
+			"type": "wysiwyg",
+			"instructions": "Enter the podcast description",
+			"required": 1,
+			"tabs": "all",
+			"toolbar": "full",
+			"media_upload": 1
+		},
+		{
+			"key": "field_podcast_platforms",
+			"label": "Podcast Platforms",
+			"name": "podcast_platforms",
+			"type": "repeater",
+			"instructions": "Add podcast platform links and badges",
+			"required": 1,
+			"min": 1,
+			"max": 0,
+			"layout": "table",
+			"button_label": "Add Platform",
+			"sub_fields": [
+				{
+					"key": "field_platform_name",
+					"label": "Platform Name",
+					"name": "name",
+					"type": "text",
+					"required": 1
+				},
+				{
+					"key": "field_platform_link",
+					"label": "Platform Link",
+					"name": "link",
+					"type": "url",
+					"required": 1
+				},
+				{
+					"key": "field_platform_badge",
+					"label": "Platform Badge",
+					"name": "badge_image",
+					"type": "image",
+					"required": 1,
+					"return_format": "url",
+					"preview_size": "medium",
+					"library": "all"
+				}
+			]
+		},
+		{
+			"key": "field_rating_message",
+			"label": "Rating Message",
+			"name": "rating_message",
+			"type": "wysiwyg",
+			"instructions": "Enter the rating message. You can include the rating link (https://www.syngap1.org/rating) directly in the text.",
+			"required": 1,
+			"tabs": "all",
+			"toolbar": "full",
+			"media_upload": 0
+		}
+	],
+	"location": [
+		[
+			{
+				"param": "taxonomy",
+				"operator": "==",
+				"value": "srf-podcasts-category"
+			}
+		]
+	],
+	"menu_order": 0,
+	"position": "normal",
+	"style": "default",
+	"label_placement": "top",
+	"instruction_placement": "label",
+	"hide_on_screen": "",
+	"active": true,
+	"description": "Settings for podcast category taxonomy terms",
+	"show_in_rest": 0,
+	"modified": 1711044000
+}

--- a/taxonomy-srf-podcasts-category.php
+++ b/taxonomy-srf-podcasts-category.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * The template for displaying the Podcasts taxonomy term archive.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @since 2024-03-21 First docBlock
+ * @package SRF
+ */
+
+namespace SRF;
+
+$container_classes = srf_container_classes();
+$term = get_queried_object();
+$term_slug = $term->slug;
+$current_term = get_term_by( 'slug', get_query_var( 'term' ), get_query_var( 'taxonomy' ) );
+
+// Get term meta if it exists
+$podcast_image = get_field('podcast_image', $term);
+$podcast_description = get_field('podcast_description', $term);
+$podcast_platforms = get_field('podcast_platforms', $term);
+$rating_message = get_field('rating_message', $term);
+$rating_link = get_field('rating_link', $term);
+
+get_header();
+?>
+
+<div class="<?php echo esc_attr( $container_classes ); ?> text-center">
+	<header class="entry-header max-w-3xl mx-auto mb-10">
+		<h1 class="entry-title mb-4 text-4xl lg:text-5xl text-gray-600 font-extrabold"><?php echo esc_html( $current_term->name ); ?></h1>
+		<div class="mx-auto w-2/3 h-1 bg-gradient-to-r from-blue-400 to-purple-400 rounded transform translate-y-2"></div>
+	</header>
+
+	<?php if (!empty($podcast_image)) : ?>
+	<div class="prose lg:prose-xl mx-auto mb-10">
+		<img src="<?php echo esc_url($podcast_image); ?>" alt="<?php echo esc_attr($current_term->name); ?>" />
+		<?php if (!empty($podcast_description)) : ?>
+			<?php echo wp_kses_post($podcast_description); ?>
+		<?php endif; ?>
+	</div>
+	<?php endif; ?>
+
+	<div class="max-w-6xl mx-auto mb-10 space-y-5 text-center">
+		<p class="prose lg:prose-xl mx-auto"><?php echo esc_html__('Listen below or find us on your podcast player of choice!', 'srf'); ?></p>
+
+		<?php if (!empty($podcast_platforms)) : ?>
+		<ul class="flex flex-wrap lg:flex-nowrap justify-center mx-auto space-x-2">
+			<?php foreach ($podcast_platforms as $platform) : ?>
+				<li class="w-1/3 mt-4 lg:mt-0">
+					<a href="<?php echo esc_url($platform['link']); ?>">
+						<img src="<?php echo esc_url($platform['badge_image']); ?>" alt="<?php echo esc_attr($platform['name']); ?>" />
+					</a>
+				</li>
+			<?php endforeach; ?>
+		</ul>
+		<?php endif; ?>
+
+		<?php if (!empty($rating_message)) : ?>
+		<div class="prose mx-auto">
+			<?php echo wp_kses_post($rating_message); ?>
+		</div>
+		<?php endif; ?>
+
+		<div class="mx-auto w-2/3 h-px bg-gradient-to-r from-blue-400 to-purple-400 rounded transform translate-y-2"></div>
+	</div>
+
+	<?php if ( have_posts() ) : ?>
+		<div class="max-w-6xl mx-auto grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
+			<?php
+			/* Start the Loop */
+			while ( have_posts() ) :
+				the_post();
+
+				/*
+				* Include the Post-Type-specific template for the content.
+				* If you want to override this in a child theme, then include a file
+				* called content-___.php (where ___ is the Post Type name) and that will be used instead.
+				*/
+				get_template_part( 'template-parts/content', 'grid-items' );
+
+			endwhile;
+			?>
+		</div>
+		<div class="max-w-6xl mx-auto mt-14 pt-10 text-center border-t-2 border-gray-200">
+			<?php
+				the_posts_navigation( array( 'prev_text' => 'Next Page', 'next_text' => 'Previous Page' ) );
+			?>
+		</div>
+	<?php else : ?>
+		<p class="text-2xl text-center italic"><?php printf(esc_html__('No %s episodes have been uploaded yet. Stay tuned!', 'srf'), esc_html($current_term->name)); ?></p>
+	<?php endif; ?>
+</div>
+
+<?php
+get_footer();


### PR DESCRIPTION
This pull request introduces functionality for managing and displaying podcast taxonomy terms in a WordPress site. The changes include the addition of Advanced Custom Fields (ACF) for podcast metadata and a new taxonomy archive template to display these details. 

### Podcast Metadata Management:

* Added ACF configuration in `acf-json/group_podcast_taxonomy.json` to define fields for podcast metadata, including image, description, platform links, and rating message. These fields are tied to the `srf-podcasts-category` taxonomy.

### Taxonomy Archive Template:

* Created `taxonomy-srf-podcasts-category.php` to display podcast taxonomy term archives. The template retrieves and displays metadata such as podcast image, description, platform links, and rating message, along with a list of posts associated with the taxonomy term.